### PR TITLE
Spell Tool Tips, Artifact Info Panel and Missing Artifacts

### DIFF
--- a/Heroes3Editor/HeroPanel.xaml
+++ b/Heroes3Editor/HeroPanel.xaml
@@ -518,33 +518,33 @@
                     </Grid.Resources>
                     <StackPanel Grid.Row="0" Grid.Column="0">
                         <GroupBox Header="Helm">
-                            <ComboBox Name="EA_Helm" ItemsSource="{Binding Path=Helms.Names}" SelectionChanged="UpdateEquippedArtifact" />
+                            <ComboBox Name="EA_Helm" MouseEnter="UpdateArtifactInfo" MouseLeave="ClearArtifactInfo" ItemsSource="{Binding Path=Helms.Names}" SelectionChanged="UpdateEquippedArtifact" />
                         </GroupBox>
                         <GroupBox Header="Neck">
-                            <ComboBox Name="EA_Neck" ItemsSource="{Binding Path=Neck.Names}" SelectionChanged="UpdateEquippedArtifact" />
+                            <ComboBox Name="EA_Neck" MouseEnter="UpdateArtifactInfo" MouseLeave="ClearArtifactInfo"  ItemsSource="{Binding Path=Neck.Names}" SelectionChanged="UpdateEquippedArtifact" />
                         </GroupBox>
                         <GroupBox Header="Armor">
-                            <ComboBox Name="EA_Armor" ItemsSource="{Binding Path=Armor.Names}" SelectionChanged="UpdateEquippedArtifact" />
+                            <ComboBox Name="EA_Armor" MouseEnter="UpdateArtifactInfo" MouseLeave="ClearArtifactInfo"  ItemsSource="{Binding Path=Armor.Names}" SelectionChanged="UpdateEquippedArtifact" />
                         </GroupBox>
                         <GroupBox Header="Cloak">
-                            <ComboBox Name="EA_Cloak" ItemsSource="{Binding Path=Cloak.Names}" SelectionChanged="UpdateEquippedArtifact" />
+                            <ComboBox Name="EA_Cloak" MouseEnter="UpdateArtifactInfo" MouseLeave="ClearArtifactInfo"  ItemsSource="{Binding Path=Cloak.Names}" SelectionChanged="UpdateEquippedArtifact" />
                         </GroupBox>
                         <GroupBox Header="Boots">
-                            <ComboBox Name="EA_Boots" ItemsSource="{Binding Path=Boots.Names}" SelectionChanged="UpdateEquippedArtifact" />
+                            <ComboBox Name="EA_Boots" MouseEnter="UpdateArtifactInfo" MouseLeave="ClearArtifactInfo"  ItemsSource="{Binding Path=Boots.Names}" SelectionChanged="UpdateEquippedArtifact" />
                         </GroupBox>
                     </StackPanel>
                     <StackPanel Grid.Row="0" Grid.Column="1">
                         <GroupBox Header="Weapon">
-                            <ComboBox Name="EA_Weapon" ItemsSource="{Binding Path=Weapons.Names}" SelectionChanged="UpdateEquippedArtifact" />
+                            <ComboBox Name="EA_Weapon" MouseEnter="UpdateArtifactInfo" MouseLeave="ClearArtifactInfo"  ItemsSource="{Binding Path=Weapons.Names}" SelectionChanged="UpdateEquippedArtifact" />
                         </GroupBox>
                         <GroupBox Header="Shield">
-                            <ComboBox Name="EA_Shield" ItemsSource="{Binding Path=Shields.Names}" SelectionChanged="UpdateEquippedArtifact" />
+                            <ComboBox Name="EA_Shield" MouseEnter="UpdateArtifactInfo" MouseLeave="ClearArtifactInfo"  ItemsSource="{Binding Path=Shields.Names}" SelectionChanged="UpdateEquippedArtifact" />
                         </GroupBox>
                         <GroupBox Header="Left Ring">
-                            <ComboBox Name="EA_LeftRing" ItemsSource="{Binding Path=Rings.Names}" SelectionChanged="UpdateEquippedArtifact" />
+                            <ComboBox Name="EA_LeftRing" MouseEnter="UpdateArtifactInfo" MouseLeave="ClearArtifactInfo"  ItemsSource="{Binding Path=Rings.Names}" SelectionChanged="UpdateEquippedArtifact" />
                         </GroupBox>
                         <GroupBox Header="Right Ring">
-                            <ComboBox Name="EA_RightRing" ItemsSource="{Binding Path=Rings.Names}" SelectionChanged="UpdateEquippedArtifact" />
+                            <ComboBox Name="EA_RightRing" MouseEnter="UpdateArtifactInfo" MouseLeave="ClearArtifactInfo"  ItemsSource="{Binding Path=Rings.Names}" SelectionChanged="UpdateEquippedArtifact" />
                         </GroupBox>
                     </StackPanel>
                     <GroupBox Header="Item Slots" Grid.Row="0" Grid.Column="2">
@@ -554,11 +554,53 @@
                                     <Setter Property="Margin" Value="0,5"/>
                                 </Style>
                             </StackPanel.Resources>
-                            <ComboBox Name="EA_Item1" ItemsSource="{Binding Path=Items.Names}" SelectionChanged="UpdateEquippedArtifact" />
-                            <ComboBox Name="EA_Item2" ItemsSource="{Binding Path=Items.Names}" SelectionChanged="UpdateEquippedArtifact" />
-                            <ComboBox Name="EA_Item3" ItemsSource="{Binding Path=Items.Names}" SelectionChanged="UpdateEquippedArtifact" />
-                            <ComboBox Name="EA_Item4" ItemsSource="{Binding Path=Items.Names}" SelectionChanged="UpdateEquippedArtifact" />
-                            <ComboBox Name="EA_Item5" ItemsSource="{Binding Path=Items.Names}" SelectionChanged="UpdateEquippedArtifact" />
+                            <ComboBox Name="EA_Item1" MouseEnter="UpdateArtifactInfo" MouseLeave="ClearArtifactInfo" ItemsSource="{Binding Path=Items.Names}" SelectionChanged="UpdateEquippedArtifact" />
+                            <ComboBox Name="EA_Item2" MouseEnter="UpdateArtifactInfo" MouseLeave="ClearArtifactInfo" ItemsSource="{Binding Path=Items.Names}" SelectionChanged="UpdateEquippedArtifact" />
+                            <ComboBox Name="EA_Item3" MouseEnter="UpdateArtifactInfo" MouseLeave="ClearArtifactInfo" ItemsSource="{Binding Path=Items.Names}" SelectionChanged="UpdateEquippedArtifact" />
+                            <ComboBox Name="EA_Item4" MouseEnter="UpdateArtifactInfo" MouseLeave="ClearArtifactInfo" ItemsSource="{Binding Path=Items.Names}" SelectionChanged="UpdateEquippedArtifact" />
+                            <ComboBox Name="EA_Item5" MouseEnter="UpdateArtifactInfo" MouseLeave="ClearArtifactInfo" ItemsSource="{Binding Path=Items.Names}" SelectionChanged="UpdateEquippedArtifact" />
+                            <GroupBox Header="Artifact Info" Name="ArtifactInfo" >
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="1*" />
+                                        <ColumnDefinition Width="1*" />
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="*" />
+                                    </Grid.RowDefinitions>
+                                    <StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="0" Margin="1">
+                                        <Label>Att:</Label>
+                                        <TextBlock TextWrapping="Wrap" Name="Attack" VerticalAlignment="Center"></TextBlock>
+                                    </StackPanel>
+                                    <StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="1" Margin="1">
+                                        <Label>Def:</Label>
+                                        <TextBlock TextWrapping="Wrap" Name="Defense" VerticalAlignment="Center"></TextBlock>
+                                    </StackPanel>
+                                    <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="0" Margin="1">
+                                        <Label>Pow:</Label>
+                                        <TextBlock TextWrapping="Wrap" Name="Power" VerticalAlignment="Center"></TextBlock>
+                                    </StackPanel>
+                                    <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="1" Margin="1">
+                                        <Label>Know:</Label>
+                                        <TextBlock TextWrapping="Wrap" Name="Knowledge" VerticalAlignment="Center"></TextBlock>
+                                    </StackPanel>
+                                    <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="0" Margin="1">
+                                        <Label>Morale:</Label>
+                                        <TextBlock TextWrapping="Wrap" Name="Morale" VerticalAlignment="Center"></TextBlock>
+                                    </StackPanel>
+                                    <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="1" Margin="1">
+                                        <Label>Luck:</Label>
+                                        <TextBlock TextWrapping="Wrap" Name="Luck" VerticalAlignment="Center"></TextBlock>
+                                    </StackPanel>
+                                    <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Margin="2">
+                                        <Label>Effects:</Label>
+                                        <TextBlock TextWrapping="WrapWithOverflow" Name="Effects" VerticalAlignment="Center" Width="135" Height="110" Margin="0,5,2,2"></TextBlock>
+                                    </StackPanel>
+                                </Grid>
+                            </GroupBox>
                         </StackPanel>
                     </GroupBox>
                 </Grid>

--- a/Heroes3Editor/HeroPanel.xaml
+++ b/Heroes3Editor/HeroPanel.xaml
@@ -117,175 +117,259 @@
                     </Grid.RowDefinitions>
                     <GroupBox Header="All Schools" Grid.Row="0" Grid.ColumnSpan="4">
                         <WrapPanel>
-                            <CheckBox Name="Magic_Arrow" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Target, enemy troop receives magic damage" Name="Magic_Arrow" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Magic Arrow</Label>
                             </CheckBox>
                             <CheckBox Name="Visions" Checked="AddSpell" Unchecked="RemoveSpell">
+                                <CheckBox.ToolTip>
+                                    <TextBlock>
+                                    Increases information shown in scouting reports of towns,
+                                    <LineBreak />
+                                    creatures and heroes.
+                                    </TextBlock>
+                                </CheckBox.ToolTip>
                                 <Label>Visions</Label>
                             </CheckBox>
                         </WrapPanel>
                     </GroupBox>
                     <GroupBox Header="Air Magic" Grid.Row="1" Grid.Column="0">
                         <StackPanel>
-                            <CheckBox Name="Haste" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Targeted allied unit(s) speed is increased." Name="Haste" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Haste</Label>
                             </CheckBox>
-                            <CheckBox Name="View_Air" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Reveals location of all unclaimed artifacts." Name="View_Air" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>View Air</Label>
                             </CheckBox>
-                            <CheckBox Name="Disguise" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Modifies the army composition scouting report visible to enemies." Name="Disguise" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Disguise</Label>
                             </CheckBox>
                             <CheckBox Name="Disrupting_Ray" Checked="AddSpell" Unchecked="RemoveSpell">
+                                <CheckBox.ToolTip>
+                                    <TextBlock>
+                                    Reduces defense rating of a single enemy.
+                                    <LineBreak />
+                                    May be used repeatedly on the same target.
+                                    </TextBlock>
+                                </CheckBox.ToolTip>
                                 <Label>Disrupting Ray</Label>
                             </CheckBox>
-                            <CheckBox Name="Fortune" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Increases luck." Name="Fortune" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Fortune</Label>
                             </CheckBox>
-                            <CheckBox Name="Lightning_Bolt" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Inflicts magic damage on a single enemy." Name="Lightning_Bolt" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Lightning Bolt</Label>
                             </CheckBox>
-                            <CheckBox Name="Precision" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Increases ranged attack rating." Name="Precision" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Precision</Label>
                             </CheckBox>
-                            <CheckBox Name="Protection_from_Air" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Reduces damage taken from air spells." Name="Protection_from_Air" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Protection from Air</Label>
                             </CheckBox>
-                            <CheckBox Name="Air_Shield" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Reduces damage taken from ranged attacks." Name="Air_Shield" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Air Shield</Label>
                             </CheckBox>
-                            <CheckBox Name="Destroy_Undead" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Inflicts magic damage on all undead creatures." Name="Destroy_Undead" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Destroy Undead</Label>
                             </CheckBox>
-                            <CheckBox Name="Hypnotize" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Allows control of actions taken by enemy creature." Name="Hypnotize" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Hypnotize</Label>
                             </CheckBox>
                             <CheckBox Name="Chain_Lightning" Checked="AddSpell" Unchecked="RemoveSpell">
+                                <CheckBox.ToolTip>
+                                    <TextBlock>
+                                    Inflicts magic damage on initial creature
+                                    <LineBreak />
+                                    and reduced damage on nearby creatures.
+                                    </TextBlock>
+                                </CheckBox.ToolTip>
                                 <Label>Chain Lightning</Label>
                             </CheckBox>
-                            <CheckBox Name="Counterstrike" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Allows extra retaliations per round." Name="Counterstrike" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Counterstrike</Label>
                             </CheckBox>
-                            <CheckBox Name="Dimension_Door" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Teleports hero to visible location." Name="Dimension_Door" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Dimension Door</Label>
                             </CheckBox>
                             <CheckBox Name="Fly" Checked="AddSpell" Unchecked="RemoveSpell">
+                                <CheckBox.ToolTip>
+                                    <TextBlock>
+                                    Allows movement to visible land over all map obstacles.
+                                    <LineBreak />
+                                    Cannot fly through cave walls in the underground.
+                                    </TextBlock>
+                                </CheckBox.ToolTip>
                                 <Label>Fly</Label>
                             </CheckBox>
-                            <CheckBox Name="Magic_Mirror" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Reflects hostile spells to a random enemy." Name="Magic_Mirror" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Magic Mirror</Label>
                             </CheckBox>
-                            <CheckBox Name="Summon_Air_Elemental" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Summons allied Air Elementals for the duration of combat." Name="Summon_Air_Elemental" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Summon Air Elemental</Label>
                             </CheckBox>
                             <CheckBox Name="Titans_Lightning_Bolt" Checked="AddSpell" Unchecked="RemoveSpell">
+                                <CheckBox.ToolTip>
+                                    <TextBlock>
+                                    Inflicts 600 magic damage on a single enemy.
+                                    <LineBreak />
+                                    Requires Titan's Thunder.
+                                    </TextBlock>
+                                </CheckBox.ToolTip>
                                 <Label>Titan's Lightning Bolt</Label>
                             </CheckBox>
                         </StackPanel>
                     </GroupBox>
                     <GroupBox Header="Earth Magic" Grid.Row="1" Grid.Column="1">
                         <StackPanel>
-                            <CheckBox Name="Shield" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Reduces damage taken from hand-to-hand attacks." Name="Shield" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Shield</Label>
                             </CheckBox>
-                            <CheckBox Name="Slow" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Decreases speed." Name="Slow" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Slow</Label>
                             </CheckBox>
-                            <CheckBox Name="Stone_Skin" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Increases defense rating." Name="Stone_Skin" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Stone Skin</Label>
                             </CheckBox>
-                            <CheckBox Name="View_Earth" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Reveals location of all resources." Name="View_Earth" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>View Earth</Label>
                             </CheckBox>
-                            <CheckBox Name="Death_Ripple" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Inflicts magic damage on all living creatures." Name="Death_Ripple" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Death Ripple</Label>
                             </CheckBox>
                             <CheckBox Name="Quick_Sand" Checked="AddSpell" Unchecked="RemoveSpell">
+                                <CheckBox.ToolTip>
+                                    <TextBlock>
+                                    Places quicksand at random locations on the battlefield.
+                                    <LineBreak />
+                                    Only visible to caster and creatures native to the terrain.
+                                    </TextBlock>
+                                </CheckBox.ToolTip>
                                 <Label>Quick Sand</Label>
                             </CheckBox>
                             <CheckBox Name="Animate_Dead" Checked="AddSpell" Unchecked="RemoveSpell">
+                                <CheckBox.ToolTip>
+                                    <TextBlock>
+                                    Reanimates killed undead creatures.
+                                    <LineBreak />
+                                    Reanimated creatures are not lost when combat ends.
+                                    </TextBlock>
+                                </CheckBox.ToolTip>
                                 <Label>Animate Dead</Label>
                             </CheckBox>
-                            <CheckBox Name="Anti_Magic" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Grants spell immunity to a single creature." Name="Anti_Magic" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Anti-Magic</Label>
                             </CheckBox>
-                            <CheckBox Name="Earthquake" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Inflicts damage on random castle wall sections during a siege." Name="Earthquake" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Earthquake</Label>
                             </CheckBox>
                             <CheckBox Name="Force_Field" Checked="AddSpell" Unchecked="RemoveSpell">
+                                <CheckBox.ToolTip>
+                                    <TextBlock>
+                                    Places force field at specified location.
+                                    <LineBreak />
+                                    Creatures cannot pass this field.
+                                    </TextBlock>
+                                </CheckBox.ToolTip>
                                 <Label>Force Field</Label>
                             </CheckBox>
-                            <CheckBox Name="Protection_from_Earth" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Reduces damage taken from earth spells." Name="Protection_from_Earth" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Protection from Earth</Label>
                             </CheckBox>
-                            <CheckBox Name="Meteor_Shower" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Inflicts magic damage on all creatures in area." Name="Meteor_Shower" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Meteor Shower</Label>
                             </CheckBox>
-                            <CheckBox Name="Resurrection" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Resurrects killed living creatures until the end of combat." Name="Resurrection" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Resurrection</Label>
                             </CheckBox>
-                            <CheckBox Name="Sorrow" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Reduces morale." Name="Sorrow" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Sorrow</Label>
                             </CheckBox>
-                            <CheckBox Name="Town_Portal" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Teleports hero to closest allied, unoccupied town." Name="Town_Portal" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Town Portal</Label>
                             </CheckBox>
-                            <CheckBox Name="Implosion" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Inflicts magic damage on a single enemy." Name="Implosion" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Implosion</Label>
                             </CheckBox>
-                            <CheckBox Name="Summon_Earth_Elemental" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Summons allied Earth Elementals for the duration of combat." Name="Summon_Earth_Elemental" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Summon Earth Elemental</Label>
                             </CheckBox>
                         </StackPanel>
                     </GroupBox>
-                    <GroupBox Header="Fir Magic" Grid.Row="1" Grid.Column="2">
+                    <GroupBox Header="Fire Magic" Grid.Row="1" Grid.Column="2">
                         <StackPanel>
-                            <CheckBox Name="Bloodlust" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Increases the attack skill of target(s) for melee attacks." Name="Bloodlust" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Bloodlust</Label>
                             </CheckBox>
-                            <CheckBox Name="Curse" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="The targeted enemy unit(s) deliver reduced damage when attacking." Name="Curse" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Curse</Label>
                             </CheckBox>
-                            <CheckBox Name="Protection_from_Fire" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Reduces damage taken from fire spells." Name="Protection_from_Fire" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Protection from Fire</Label>
                             </CheckBox>
-                            <CheckBox Name="Blind" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Prevents any action from being taken by target enemy creature." Name="Blind" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Blind</Label>
                             </CheckBox>
                             <CheckBox Name="Fire_Wall" Checked="AddSpell" Unchecked="RemoveSpell">
+                                <CheckBox.ToolTip>
+                                    <TextBlock>
+                                    Creates wall of fire at target location that inflicts
+                                    <LineBreak />
+                                    magic damage on creatures that pass through.
+                                    </TextBlock>
+                                </CheckBox.ToolTip>
                                 <Label>Fire Wall</Label>
                             </CheckBox>
-                            <CheckBox Name="Fireball" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Inflicts magic damage on all creatures in area." Name="Fireball" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Fireball</Label>
                             </CheckBox>
                             <CheckBox Name="Land_Mine" Checked="AddSpell" Unchecked="RemoveSpell">
+                                <CheckBox.ToolTip>
+                                    <TextBlock>
+                                    Places landmines at random locations on the battlefield.
+                                    <LineBreak />
+                                    Only visible to caster and creatures native to the terrain.
+                                    </TextBlock>
+                                </CheckBox.ToolTip>
                                 <Label>Land Mine</Label>
                             </CheckBox>
-                            <CheckBox Name="Misfortune" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Reduces luck." Name="Misfortune" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Misfortune</Label>
                             </CheckBox>
-                            <CheckBox Name="Armageddon" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Inflicts magic damage on all creatures on the battlefield." Name="Armageddon" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Armageddon</Label>
                             </CheckBox>
-                            <CheckBox Name="Berserk" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Forces enemy to attack closest creature." Name="Berserk" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Berserk</Label>
                             </CheckBox>
-                            <CheckBox Name="Fire_Shield" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Inflicts magic damage proportional to damage taken from hand-to-hand attacks." Name="Fire_Shield" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Fire Shield</Label>
                             </CheckBox>
-                            <CheckBox Name="Frenzy" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Increases attack rating and sets defense rating to 0." Name="Frenzy" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Frenzy</Label>
                             </CheckBox>
-                            <CheckBox Name="Inferno" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Inflicts magic damage on all creatures in area." Name="Inferno" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Inferno</Label>
                             </CheckBox>
                             <CheckBox Name="Slayer" Checked="AddSpell" Unchecked="RemoveSpell">
+                                <CheckBox.ToolTip>
+                                    <TextBlock>
+                                    Increases attack rating of a single ally against Dragons, Behemoths,
+                                    <LineBreak />
+                                    Hydras, Angels, Devils and Titans.
+                                    </TextBlock>
+                                </CheckBox.ToolTip>
                                 <Label>Slayer</Label>
                             </CheckBox>
                             <CheckBox Name="Sacrifice" Checked="AddSpell" Unchecked="RemoveSpell">
+                                <CheckBox.ToolTip>
+                                    <TextBlock>
+                                    Destroys and removes living, unkilled allies to bring
+                                    <LineBreak />
+                                    previously living, killed allies back to life.
+                                    </TextBlock>
+                                </CheckBox.ToolTip>
                                 <Label>Sacrifice</Label>
                             </CheckBox>
-                            <CheckBox Name="Summon_Fire_Elemental" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Summons allied Fire Elementals for the duration of combat." Name="Summon_Fire_Elemental" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Summon Fire Elemental</Label>
                             </CheckBox>
                         </StackPanel>
@@ -293,54 +377,69 @@
                     <GroupBox Header="Water Magic" Grid.Row="1" Grid.Column="3">
                         <StackPanel>
                             <CheckBox Name="Cure" Checked="AddSpell" Unchecked="RemoveSpell">
+                                <CheckBox.ToolTip>
+                                    <TextBlock>
+                                    Removes all negative spell effects from allied target(s)
+                                    <LineBreak />
+                                    and heals some hitpoints.
+                                    </TextBlock>
+                                </CheckBox.ToolTip>
                                 <Label>Cure</Label>
                             </CheckBox>
                             <CheckBox Name="Dispel" Checked="AddSpell" Unchecked="RemoveSpell">
+                                <CheckBox.ToolTip>
+                                    <TextBlock>
+                                    Removes all spell effects from target allied,
+                                    <LineBreak />
+                                    enemy or all creatures and the battlefield.
+                                    </TextBlock>
+                                </CheckBox.ToolTip>
                                 <Label>Dispel</Label>
                             </CheckBox>
-                            <CheckBox Name="Bless" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Targeted allied creature(s) inflict maximum damage when they attack." Name="Bless" Checked="AddSpell" Unchecked="RemoveSpell">
+                                
                                 <Label>Bless</Label>
                             </CheckBox>
-                            <CheckBox Name="Protection_from_Water" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Reduces damage taken from water spells." Name="Protection_from_Water" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Protection from Water</Label>
                             </CheckBox>
-                            <CheckBox Name="Summon_Boat" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Summons unoccupied boat to nearby body of water." Name="Summon_Boat" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Summon Boat</Label>
                             </CheckBox>
-                            <CheckBox Name="Ice_Bolt" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Inflicts magic damage on a single enemy." Name="Ice_Bolt" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Ice Bolt</Label>
                             </CheckBox>
-                            <CheckBox Name="Remove_Obstacle" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Removes obstacles from the battlefield." Name="Remove_Obstacle" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Remove Obstacle</Label>
                             </CheckBox>
-                            <CheckBox Name="Scuttle_Boat" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Destroys nearby unoccupied boat." Name="Scuttle_Boat" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Scuttle Boat</Label>
                             </CheckBox>
-                            <CheckBox Name="Weakness" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Reduces attack rating." Name="Weakness" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Weakness</Label>
                             </CheckBox>
-                            <CheckBox Name="Forgetfulness" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Prevents use of ranged attacks." Name="Forgetfulness" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Forgetfulness</Label>
                             </CheckBox>
-                            <CheckBox Name="Frost_Ring" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Inflicts magic damage on all creatures in area." Name="Frost_Ring" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Frost Ring</Label>
                             </CheckBox>
-                            <CheckBox Name="Mirth" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Increases morale." Name="Mirth" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Mirth</Label>
                             </CheckBox>
-                            <CheckBox Name="Teleport" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Teleports ally to location on the battlefield." Name="Teleport" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Teleport</Label>
                             </CheckBox>
-                            <CheckBox Name="Clone" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Creates clone of allied creature." Name="Clone" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Clone</Label>
                             </CheckBox>
-                            <CheckBox Name="Prayer" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Increases attack rating, defense rating and speed." Name="Prayer" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Prayer</Label>
                             </CheckBox>
-                            <CheckBox Name="Water_Walk" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Allows movement to visible land across bodies of water." Name="Water_Walk" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Water Walk</Label>
                             </CheckBox>
-                            <CheckBox Name="Summon_Water_Elemental" Checked="AddSpell" Unchecked="RemoveSpell">
+                            <CheckBox ToolTip="Summons allied Water Elementals for the duration of combat." Name="Summon_Water_Elemental" Checked="AddSpell" Unchecked="RemoveSpell">
                                 <Label>Summon Water Elemental</Label>
                             </CheckBox>
                         </StackPanel>

--- a/Heroes3Editor/HeroPanel.xaml.cs
+++ b/Heroes3Editor/HeroPanel.xaml.cs
@@ -202,5 +202,53 @@ namespace Heroes3Editor
             var artifact = cboBox.SelectedItem as string;
             _hero.UpdateEquippedArtifact(gear, artifact);
         }
+
+        private void UpdateArtifactInfo(object sender, RoutedEventArgs e)
+        {
+            var cboBox = e.Source as ComboBox;
+            var artifact = cboBox.SelectedItem as string;
+
+            if (null != _hero.UpdateArtifactInfo(artifact))
+            {
+                var txtBlock = FindName("Attack") as TextBlock;
+                txtBlock.Text = _hero.UpdateArtifactInfo(artifact)[1];
+
+                txtBlock = FindName("Defense") as TextBlock;
+                txtBlock.Text = _hero.UpdateArtifactInfo(artifact)[2];
+
+                txtBlock = FindName("Power") as TextBlock;
+                txtBlock.Text = _hero.UpdateArtifactInfo(artifact)[3];
+
+                txtBlock = FindName("Knowledge") as TextBlock;
+                txtBlock.Text = _hero.UpdateArtifactInfo(artifact)[4];
+
+                txtBlock = FindName("Morale") as TextBlock;
+                txtBlock.Text = _hero.UpdateArtifactInfo(artifact)[5];
+
+                txtBlock = FindName("Luck") as TextBlock;
+                txtBlock.Text = _hero.UpdateArtifactInfo(artifact)[6];
+
+                txtBlock = FindName("Effects") as TextBlock;
+                txtBlock.Text = _hero.UpdateArtifactInfo(artifact)[7];
+            }
+        }
+
+        private void ClearArtifactInfo(object sender, RoutedEventArgs e)
+        {
+            var txtBlock = FindName("Attack") as TextBlock;
+            txtBlock.Text = "";
+            txtBlock = FindName("Defense") as TextBlock;
+            txtBlock.Text = "";
+            txtBlock = FindName("Power") as TextBlock;
+            txtBlock.Text = "";
+            txtBlock = FindName("Knowledge") as TextBlock;
+            txtBlock.Text = "";
+            txtBlock = FindName("Morale") as TextBlock;
+            txtBlock.Text = "";
+            txtBlock = FindName("Luck") as TextBlock;
+            txtBlock.Text = "";
+            txtBlock = FindName("Effects") as TextBlock;
+            txtBlock.Text = "";
+        }
     }
 }

--- a/Heroes3Editor/Models/Constants.cs
+++ b/Heroes3Editor/Models/Constants.cs
@@ -20,6 +20,8 @@ namespace Heroes3Editor.Models
         public static WarMachines WarMachines { get; } = new WarMachines();
         public static Artifacts Artifacts { get; } = new Artifacts();
 
+        public static ArtifactInfo ArtifactInfo { get; } = new ArtifactInfo();
+
         public static string[] Heroes { get; } =
         {
             "Christian", "Edric", "Orrin", "Sylvia", "Valeska", "Sorsha", "Tyris", "Lord Haart", "Catherine",
@@ -37,7 +39,7 @@ namespace Heroes3Editor.Models
             "Oris", "Saurug", "Terek", "Vey", "Zubin", "Alkin", "Broghild", "Bron", "Drakon", "Gerwulf", "Korbac",
             "Tazar", "Wystan", "Andra", "Merist", "Mirlanda", "Rosic", "Styg", "Tiva", "Verdish", "Voy", "Adrienne",
             "Erdamon", "Fiur", "Ignissa", "Kalt", "Lacus", "Monere", "Pasis", "Thunar", "Aenain", "Brissa", "Ciele",
-            "Gelare", "Grindan", "Inteus", "Labetha", "Luna"
+            "Gelare", "Grindan", "Inteus", "Labetha", "Luna", "Gen. Kendal"
         };
 
         public static Dictionary<string, int> HeroOffsets = new Dictionary<string, int>()
@@ -126,7 +128,10 @@ namespace Heroes3Editor.Models
             {0x0B, "Sword of Hellfire" },
             {0X0C, "Titan's Gladius" },
             {0x11, "Sword of Judgement" },
-            {0x26, "Red Dragon Flame Tongue" }
+            {0x26, "Red Dragon Flame Tongue" },
+            {0x80, "Armageddon's Blade" },
+            {0x81, "Angelic Alliance" },
+            {0x87, "Titans Thunder" }
         };
 
         private static readonly Dictionary<string, byte> _codesByName = _namesByCode.ToDictionary(i => i.Value, i => i.Key);
@@ -176,7 +181,8 @@ namespace Heroes3Editor.Models
             {0x24, "Helm of Heavenly Enlightenment" },
             {0x2C, "Crown of Dragontooth" },
             {0x7B, "Sea Captain's Hat" },
-            {0x7C, "Spellbinder's Hat" }
+            {0x7C, "Spellbinder's Hat" },
+            {0x88, "Admiral's Hat" }
         };
 
         private static readonly Dictionary<string, byte> _codesByName = _namesByCode.ToDictionary(i => i.Value, i => i.Key);
@@ -201,7 +207,9 @@ namespace Heroes3Editor.Models
             {0x1E, "Titan's Cuirass" },
             {0x1F, "Armor of Wonder" },
             {0x28, "Dragon Scale Armor" },
-            {0x3A, "Surcoat of Counterpoise" }
+            {0x3A, "Surcoat of Counterpoise" },
+            {0x84, "Armor of the Dammed" },
+            {0x86, "Power of the Dragon Father" }
         };
 
         private static readonly Dictionary<string, byte> _codesByName = _namesByCode.ToDictionary(i => i.Value, i => i.Key);
@@ -225,7 +233,8 @@ namespace Heroes3Editor.Models
             {0x4E, "Cape of Conjuring" },
             {0x53, "Recanter's Cloak" },
             {0x63, "Cape of Velocity" },
-            {0x6D, "Everflowing Crystal Cloak" }
+            {0x6D, "Everflowing Crystal Cloak" },
+            {0x82, "Cloak of Undead King" }
         };
 
         private static readonly Dictionary<string, byte> _codesByName = _namesByCode.ToDictionary(i => i.Value, i => i.Key);
@@ -277,7 +286,7 @@ namespace Heroes3Editor.Models
             {0x67, "Pendant of Life" },
             {0x68, "Pendant of Death" },
             {0x69, "Pendant of Free Will" },
-            {0x6A, "Pendant of Agitation" },
+            {0x6A, "Pendant of Negativity" },
             {0x6B, "Pendant of Total Recall" },
             {0x6C, "Pendant of Courage" }
         };
@@ -366,7 +375,10 @@ namespace Heroes3Editor.Models
             {0x79, "Arms of Legion" },
             {0x7A, "Head of Legion" },
             {0x7D, "Shackles of War" },
-            {0x7E, "Orb of Inhibition" }
+            {0x7E, "Orb of Inhibition" },
+            {0x83, "Elixir of Life" },
+            {0x85, "Statue of Legion" },
+            {0x89, "Bow of the Sharpshooter" }
         };
 
         private static readonly Dictionary<string, byte> _codesByName = _namesByCode.ToDictionary(i => i.Value, i => i.Key);
@@ -506,13 +518,14 @@ namespace Heroes3Editor.Models
             {0x67, "Pendant of Life" },
             {0x68, "Pendant of Death" },
             {0x69, "Pendant of Free Will" },
-            {0x6A, "Pendant of Agitation" },
+            {0x6A, "Pendant of Negativity" },
             {0x6B, "Pendant of Total Recall" },
             {0x6C, "Pendant of Courage" },
             {0x6D, "Everflowing Crystal Cloak" },
             {0x6E, "Ring of Infinite Gems" },
             {0x6F, "Everpouring Vial of Mercury" },
             {0x70, "Inexhaustable Cart of Ore" },
+            {0x71, "Eversmoking Ring of Sulfur" },
             {0x72, "Inexhaustable Cart of Lumber" },
             {0x73, "Endless Sack of Gold" },
             {0x74, "Endless Bag of Gold" },
@@ -522,19 +535,169 @@ namespace Heroes3Editor.Models
             {0x78, "Torso of Legion" },
             {0x79, "Arms of Legion" },
             {0x7A, "Head of Legion" },
+            {0x7B, "Sea Captain's Hat" },
+            {0x7C, "Spellbinder's Hat" },
             {0x7D, "Shackles of War" },
             {0x7E, "Orb of Inhibition" },
             {0x7F, "Vial of Dragonblood" },
-            {0x80, "Armageddon's blade" },
+            {0x80, "Armageddon's Blade" },
             {0x81, "Angelic Alliance" },
             {0x82, "Cloak of Undead King" },
-            {0x83, "Elixir of life" },
+            {0x83, "Elixir of Life" },
             {0x84, "Armor of the Dammed" },
-            {0x85, "Statue of Legions" },
+            {0x85, "Statue of Legion" },
             {0x86, "Power of the Dragon Father" },
             {0x87, "Titans Thunder" },
             {0x88, "Admiral's Hat" },
             {0x89, "Bow of the Sharpshooter" }
+        };
+
+        private static readonly Dictionary<string, byte> _codesByName = _namesByCode.ToDictionary(i => i.Value, i => i.Key);
+
+        public string[] Names { get; } = _namesByCode.Values.ToArray();
+
+        public string this[byte key] => _namesByCode[key];
+
+        public byte this[string key] => _codesByName[key];
+    }
+
+    public class ArtifactInfo
+    {
+        //  NAME|ATTACK|DEFENSE|SPELL POWER|KNOWLEDGE|MORALE|LUCK|OTHER
+        //   0  |   1  |   2   |     3     |    4    |   5  |  6 |  7
+        private static readonly Dictionary<byte, string> _namesByCode = new Dictionary<byte, string>()
+        {
+            {0x07, "Centaur's Axe|+2||||||" },
+            {0x08, "Blackshard of the Dead Knight|+3||||||" },
+            {0x09, "Greater Knoll's Flail|+4||||||" },
+            {0x0A, "Ogre's Club of Havoc|+5||||||" },
+            {0x0B, "Sword of Hellfire|+6||||||" },
+            {0X0C, "Titan's Gladius|+12|-3|||||" },
+            {0x0D, "Shield of the Dwarven Lords||+2|||||" },
+            {0x0E, "Shield of the Yawning Dead||+3|||||" },
+            {0x0F, "Buckler of the Gnoll King||+4|||||" },
+            {0x10, "Targ of the Rampaging Ogre||+5|||||" },
+            {0x11, "Shield of the Damned||+6|||||" },
+            {0x12, "Sentinel's Shield|-3|+12|||||" },
+            {0x13, "Helm of the Alabaster Unicorn||||+1|||" },
+            {0x14, "Skull Helmet||||+2|||" },
+            {0x15, "Helm of Chaos||||+3|||" },
+            {0x16, "Crown of the Supreme Magi||||+4|||" },
+            {0x17, "Hellstorm Helmet||||+5|||" },
+            {0x18, "Thunder Helmet|||-2|+10|||" },
+            {0x19, "Breastplate of Petrified Wood|||+1||||" },
+            {0x1A, "Rib Cage|||+2||||" },
+            {0x1B, "Scales of the Greater Basilisk|||+3||||" },
+            {0x1C, "Tunic of the Cyclops King|||+4||||" },
+            {0x1D, "Breastplate of Brimstone|||+5||||" },
+            {0x1E, "Titan's Cuirass|||+10|-2|||" },
+            {0x1F, "Armor of Wonder|+1|+1|+1|+1|||" },
+            {0x20, "Sandal's of the Saint|+2|+2|+2|+2|||" },
+            {0x21, "Celestial Necklace of Bliss|+3|+3|+3|+3|||" },
+            {0x22, "Lion's Shield of Courage|+4|+4|+4|+4|||" },
+            {0x23, "Sword of Judgement|+5|+5|+5|+5|||" },
+            {0x24, "Helm of Heavenly Enlightenment|+6|+6|+6|+6|||" },
+            {0x25, "Quiet Eye of the Dragon|+1|+1|||||" },
+            {0x26, "Red Dragon Flame Tongue|+2|+2|||||" },
+            {0x27, "Dragon Scale Shield|+3|+3|||||" },
+            {0x28, "Dragon Scale Armor|+4|+4|||||" },
+            {0x29, "Dragonbone Greaves|||+1|+1|||" },
+            {0x2A, "Dragon Wing Tabard|||+2|+2|||" },
+            {0x2B, "Necklace of Dragonteeth|||+3|+3|||" },
+            {0x2C, "Crown of Dragontooth|||+4|+4|||" },
+            {0x2D, "Still Eye of the Dragon|||||+1|+1|" },
+            {0x2E, "Clover of Fortune||||||+1|" },
+            {0x2F, "Cards of Prophecy||||||+1|" },
+            {0x30, "Ladybird of Luck||||||+1|" },
+            {0x31, "Badge of Courage|||||+1||" },
+            {0x32, "Crest of Valor|||||+1||" },
+            {0x33, "Glyph of Gallantry|||||+1||" },
+            {0x34, "Speculum|||||||Scouting Radius +1" },
+            {0x35, "Spyglass|||||||Scouting Radius +1" },
+            {0x36, "Amulet of the Undertaker|||||||Necromancy +5%" },
+            {0x37, "Vampire's Cowl|||||||Necromancy 10%" },
+            {0x38, "Dead Men's Boots|||||||Necromancy 15%" },
+            {0x39, "Garniture of Interference|||||||Magic Resistance 5%" },
+            {0x3A, "Surcoat of Counterpoise|||||||Magic Resistance 10%" },
+            {0x3B, "Boots of Polarity|||||||Magic Resistance 15%" },
+            {0x3C, "Bow of Elven Cherrywood|||||||Archery Skill 5%" },
+            {0x3D, "Bowstring of the Unicorns's Mane|||||||Archery Skill 10%" },
+            {0x3E, "Angel Feather Arrows|||||||Archery Skill 15%" },
+            {0x3F, "Bird of Perception|||||||Eagle Eye Skill 5%" },
+            {0x40, "Stoic Watchman|||||||Eagle Eye Skill 10%" },
+            {0x41, "Emblem of Cognizance|||||||Eagle Eye Skill 15%" },
+            {0x42, "Statesmen's Medal|||||||Surrendering Cost -10%" },
+            {0x43, "Diplomat Ring|||||||Surrendering Cost -10%" },
+            {0x44, "Ambassador's Sash|||||||Surrendering Cost -10%" },
+            {0x45, "Ring of the Wayfarer|||||||Unit Speed +1" },
+            {0x46, "Equestrian's Gloves|||||||Hero Movement Points +300" },
+            {0x47, "Necklace of Ocean Guidance|||||||Hero Sea Movement +1000" },
+            {0x48, "Angel Wings|||||||Hero will fly" },
+            {0x49, "Charm of Mana|||||||Regenerate +1 Mana per day" },
+            {0x4A, "Talisman of Mana|||||||Regenerate +2 Mana per day" },
+            {0x4B, "Mystic Orb of Mana|||||||Regenerate +3 Mana per day" },
+            {0x4C, "Collar of Conjuring|||||||Spell Duration +1" },
+            {0x4D, "Ring of Conjuring|||||||Spell Duration +2" },
+            {0x4E, "Cape of Conjuring|||||||Spell Duration +3" },
+            {0x4F, "Orb of Firmament|||||||All Air Spell Damage +50%" },
+            {0x50, "Orb of Silt|||||||All Earth Spell Damage +50%" },
+            {0x51, "Orb of Tempestous Fire|||||||All Fire Spell Damage +50%" },
+            {0x52, "Orb of Driving Rain|||||||All Water Spell Damage +50%" },
+            {0x53, "Recanter's Cloak|||||||Prevents Casting lvl 3+ Spells" },
+            {0x54, "Spirit of Opression|||||||Positive Morale Disabled" },
+            {0x55, "Hourglass of the Evil Hour|||||||Luck Disabled" },
+            {0x56, "Tome of Fire Magic|||||||All Fire Spells Unlocked" },
+            {0x57, "Tome of Wind Magic|||||||All Air Spells Unlocked" },
+            {0x58, "Tome of Water Magic|||||||All Water Spells Unlocked" },
+            {0x59, "Tome of Earth Magic|||||||All Earth Spells Unlocked" },
+            {0x5A, "Boots of Levitation|||||||Hero Will Walk on Water" },
+            {0x5B, "Golden Bow|||||||No Range and Obstacle Penalty" },
+            {0x5C, "Sphere of Permanence|||||||Immune to Dispel" },
+            {0x5D, "Orb of Vulnerability|||||||All Spells Unlocked, Negates Immunities" },
+            {0x5E, "Ring of Vitality|||||||+1 Unit Health" },
+            {0x5F, "Ring of Life|||||||+1 Unit Health" },
+            {0x60, "Vial of Lifeblood|||||||+2 Unit Health" },
+            {0x61, "Necklace of Swiftness|||||||+1 Unit Speed" },
+            {0x62, "Boots of Speed|||||||Hero Movement Points +600" },
+            {0x63, "Cape of Velocity|||||||+2 Unit Speed" },
+            {0x64, "Pendant of Dispassion|||||||Immunity to Berserk" },
+            {0x65, "Pendant of Second Sight|||||||Immunity to Blind" },
+            {0x66, "Pendant of Holiness|||||||Immunity to Curse" },
+            {0x67, "Pendant of Life|||||||Immunity to Death Ripple" },
+            {0x68, "Pendant of Death|||||||Immunity to Destroy Undead" },
+            {0x69, "Pendant of Free Will|||||||Immunity to Hypnotize" },
+            {0x6A, "Pendant of Negativity|||||||Immunity to Lightning Bolt and Chain-Lightning" },
+            {0x6B, "Pendant of Total Recall|||||||Immunity to Forgetfulness" },
+            {0x6C, "Pendant of Courage|||||+3|+3|" },
+            {0x6D, "Everflowing Crystal Cloak|||||||+1 Crystal per day" },
+            {0x6E, "Ring of Infinite Gems|||||||+1 Gems per day" },
+            {0x6F, "Everpouring Vial of Mercury|||||||+1 Mercury per day" },
+            {0x70, "Inexhaustable Cart of Ore|||||||+1 Ore per day" },
+            {0x71, "Eversmoking Ring of Sulfur|||||||+1 Sulfur per day" },
+            {0x72, "Inexhaustable Cart of Lumber|||||||+1 Lumber per day" },
+            {0x73, "Endless Sack of Gold|||||||+1000 Gold per day" },
+            {0x74, "Endless Bag of Gold|||||||+750 Gold per day" },
+            {0x75, "Endless Purse of Gold|||||||+500 Gold per day" },
+            {0x76, "Legs of Legion|||||||Lvl 2 Creature Growth +5" },
+            {0x77, "Loins of Legion|||||||Lvl 3 Creature Growth +4" },
+            {0x78, "Torso of Legion|||||||Lvl 4 Creature Growth +3" },
+            {0x79, "Arms of Legion|||||||Lvl 5 Creature Growth +2" },
+            {0x7A, "Head of Legion|||||||Lvl 6 Creature Growth +1" },
+            {0x7B, "Sea Captain's Hat|||||||Hero Sea Movement +500, Can Cast Summon Boat, Scuttle Boat, Protection from Whirlpools" },
+            {0x7C, "Spellbinder's Hat|||||||When equipped, the hat enables hero to cast all 5th level spells." },
+            {0x7D, "Shackles of War|||||||Neither you nor your opponent may flee or surrender" },
+            {0x7E, "Orb of Inhibition|||||||Prevents Casting All Spells" },
+            {0x7F, "Vial of Dragonblood|||||||Dragons receive +5 Attack and Defense" },
+            {0x80, "Armageddon's Blade|+3|+3|+3|+6|||Combination Artifact: Can Cast Armageddon, Immune to Armageddon"},
+            {0x81, "Angelic Alliance|+21|+21|+21|+21|||Combination Artifact: No Army Penalty for Good and Neutral troops, Can Cast Prayer" },
+            {0x82, "Cloak of Undead King|||||||Combination Artifact: Necromancy +60%, Raise more Creature Types" },
+            {0x83, "Elixir of Life|||||||Combination Artifact: +25% Unit Health, +4 Health Point Regeneration" },
+            {0x84, "Armor of the Dammed|+3|+3|+2|+2|||Combination Artifact: Cast Slow,Curse,Weakness and Misfortune for 50 rounds in combat." },
+            {0x85, "Statue of Legion|||||||Combination Artifact: Creature Growth +50% + Artifact Effects" },
+            {0x86, "Power of the Dragon Father|+16|+16|+16|+16|+1|+1|Combination Artifact: Immune to Lvl 1-4 Spells" },
+            {0x87, "Titans Thunder|+9|+9|+8|+8|||Combination Artifact: Can Cast Titan's Lightning Bolt" },
+            {0x88, "Admiral's Hat|||||||Combination Artifact: Hero Sea Movement +1500, No Penalty to Board/Leave Boat, Can Cast Summon Boat and Scuttle Boat, Protection from Whirlpools." },
+            {0x89, "Bow of the Sharpshooter|||||||Combination Artifact: No Range and Obstacle Penalty, No Melee Penalty, Archery Skill +30%" }
         };
 
         private static readonly Dictionary<string, byte> _codesByName = _namesByCode.ToDictionary(i => i.Value, i => i.Key);

--- a/Heroes3Editor/Models/Game.cs
+++ b/Heroes3Editor/Models/Game.cs
@@ -146,7 +146,7 @@ namespace Heroes3Editor.Models
             for (int i = 0; i < 7; ++i)
             {
                 var code = _game.Bytes[BytePosition + Constants.HeroOffsets["Creatures"] + i * 4];
-                if (code != 0xFF)
+                if (code != OFF)
                 {
                     Creatures[i] = Constants.Creatures[code];
                     var amountBytes = _game.Bytes.AsSpan().Slice(BytePosition + Constants.HeroOffsets["CreatureAmounts"] + i * 4, 4);
@@ -168,7 +168,7 @@ namespace Heroes3Editor.Models
             foreach (var gear in gears)
             {
                 var code = _game.Bytes[BytePosition + Constants.HeroOffsets[gear]];
-                if (code != 0xFF)
+                if (code != OFF)
                     EquippedArtifacts[gear] = Constants.Artifacts[code];
             }
         }

--- a/Heroes3Editor/Models/Game.cs
+++ b/Heroes3Editor/Models/Game.cs
@@ -95,6 +95,7 @@ namespace Heroes3Editor.Models
         public int[] CreatureAmounts { get; } = new int[7];
 
         public ISet<string> WarMachines { get; } = new HashSet<string>();
+        public string[] ArtifactInfo { get; } = new string[1];
 
         public IDictionary<string, string> EquippedArtifacts = new Dictionary<string, string>()
         {
@@ -300,6 +301,17 @@ namespace Heroes3Editor.Models
                 _game.Bytes[currentBytePos + 2] = OFF;
                 _game.Bytes[currentBytePos + 3] = OFF;
             }
+        }
+
+        //  NAME|ATTACK|DEFENSE|POWER|KNOWLEDGE|MORALE|LUCK|OTHER
+        //   0  |   1  |   2   |  3  |    4    |   5  |  6 |  7
+        public string[] UpdateArtifactInfo(string artifact)
+        {
+            if (null != artifact && !"None".Equals(artifact))
+            {
+                return Constants.ArtifactInfo[Constants.Artifacts[artifact]].Split("|");
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
In this update I have added the ability to see what a spell does by hovering over it, a tooltip will display which describes the spell. Also adding artifacts to your hero is great but it's hard to remember what all these artifacts do. The new Artifact Info panel found directly under the miscellaneous slots describes what an artifact does, all you have to do is hover over an equipped artifact to see the benefit it brings. Lastly, there were a few artifacts that were either missing from lists altogether or placed in the wrong list, oh and Gen. Kendal was missing from the Heroes list. These have been remedied. Once again, feel free to reorganize or change the code any way you wish. 